### PR TITLE
Cadence release 15

### DIFF
--- a/docs/Todo.md
+++ b/docs/Todo.md
@@ -11,10 +11,6 @@
 
 * use razor page css isolation?
 
-* does moj js do anything with filter?
- if not, don't include
-if so, initialize individual component, https://design-patterns.service.justice.gov.uk/get-started/setting-up-javascript/
-
 * gap between h1 and back seems large (although seems to match at least some other gov.uk sites).
  prototype has a custom 1em padding-top, perhaps we should duplicate the prototype
 

--- a/docs/Todo.md
+++ b/docs/Todo.md
@@ -4,14 +4,6 @@
 
 * add js tests for govuk-design-system sourced js (https://github.com/alphagov/govuk-design-system)
 
-* filtering by free is returning services with a cost with the new data import set
-
-* sass: pick up sass exe from .bin folder?
-
-* now that the API filters by organisation type, we could pass back the organisation (or what we need from the org), rather than fetching the service's org
-
-* add category as data-attribute to services to help front end tests
-
 * we could read the categories from the db (OpenReferralTaxonomy) and automatically pick up any changes to the categories
  (reuse old service to update data on the fly)
 
@@ -26,16 +18,10 @@ if so, initialize individual component, https://design-patterns.service.justice.
 * gap between h1 and back seems large (although seems to match at least some other gov.uk sites).
  prototype has a custom 1em padding-top, perhaps we should duplicate the prototype
 
-* cookie consent : which version to use?
-
-* app services doesn't support codeless app insights with .net 7
-add manually (Martin may have done something in shared)
-
 * optimse css and js
+* pick up jquery from one of the big cdn's (google/ms/jquery) with fallback to local copy (optimisation)
 
 * accessible autocomplete?
-
-* pick up jquery from one of the big cdn's (google/ms/jquery) with fallback to local copy (optimisation)
 
 * generate ie8 css using $govuk-is-ie8. & ie8 version of moj too (same https://design-patterns.service.justice.gov.uk/get-started/supporting-internet-explorer-8/)
  revert to non-js version of website for internet explorer (saves a lot of hassle), don't think html5shiv is required if we don't support js on ie.
@@ -43,15 +29,11 @@ add manually (Martin may have done something in shared)
 
 * improve sass integration
 
-current instructions:
-install sass _globally_, using
-`npm install -g sass`
+	pick up sass exe from .bin folder?
+	
+	or
 
-run
-`npm run-script scss`
-to generate the css from the sass (and watch for changes)
-
-better to use the version of sass installed to the project, using js, similar to...
+	use the version of sass installed to the project, using js, similar to...
 
 ```
 const sass = require('sass');
@@ -73,5 +55,3 @@ changes from fh-referral-ui
 swapped from node-sass (libsass) to sass (dart sass)
 see... https://frontend.design-system.service.gov.uk/installing-with-npm/#install-with-node-js-package-manager-npm
 `Do not use either LibSass or Ruby Sass, which are deprecated, for new projects.`
-
-* sonarscanner for .net vs SonarAnalyzer.CSharp? why 2? only latter supports .net 7 so stick with it for now

--- a/src/FamilyHubs.ServiceDirectory.Core/HealthCheck/IHealthCheckUrlGroup.cs
+++ b/src/FamilyHubs.ServiceDirectory.Core/HealthCheck/IHealthCheckUrlGroup.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 
-namespace FamilyHubs.ServiceDirectory.Infrastructure.HealthCheck;
+namespace FamilyHubs.ServiceDirectory.Core.HealthCheck;
 
 public interface IHealthCheckUrlGroup
 {

--- a/src/FamilyHubs.ServiceDirectory.Infrastructure/Services/PostcodesIo/PostcodesIoLookup.cs
+++ b/src/FamilyHubs.ServiceDirectory.Infrastructure/Services/PostcodesIo/PostcodesIoLookup.cs
@@ -1,7 +1,7 @@
 ﻿using FamilyHubs.ServiceDirectory.Core.Exceptions;
+using FamilyHubs.ServiceDirectory.Core.HealthCheck;
 using FamilyHubs.ServiceDirectory.Core.Postcode.Interfaces;
 using FamilyHubs.ServiceDirectory.Core.Postcode.Model;
-using FamilyHubs.ServiceDirectory.Infrastructure.HealthCheck;
 using Microsoft.Extensions.Configuration;
 
 namespace FamilyHubs.ServiceDirectory.Infrastructure.Services.PostcodesIo;

--- a/src/FamilyHubs.ServiceDirectory.Infrastructure/Services/ServiceDirectory/ServiceDirectoryClient.cs
+++ b/src/FamilyHubs.ServiceDirectory.Infrastructure/Services/ServiceDirectory/ServiceDirectoryClient.cs
@@ -7,9 +7,9 @@ using FamilyHubs.ServiceDirectory.Core.ServiceDirectory.Models;
 using FamilyHubs.ServiceDirectory.Core.UrlHelpers;
 using FamilyHubs.ServiceDirectory.Shared.Models.Api.OpenReferralOrganisations;
 using Microsoft.Extensions.Caching.Memory;
-using FamilyHubs.ServiceDirectory.Infrastructure.HealthCheck;
 using Microsoft.Extensions.Configuration;
 using FamilyHubs.ServiceDirectory.Core.Exceptions;
+using FamilyHubs.ServiceDirectory.Core.HealthCheck;
 
 namespace FamilyHubs.ServiceDirectory.Infrastructure.Services.ServiceDirectory;
 

--- a/src/FamilyHubs.ServiceDirectory.Web/Pages/Cookies/Index.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Web/Pages/Cookies/Index.cshtml
@@ -32,7 +32,7 @@
                 <li>remember what notifications you've seen, so you're not shown them more than once</li>
                 <li>temporarily store the selections you make</li>
             </ul>
-            <p>Find out more about <a href="https://ico.org.uk/your-data-matters/online/cookies/" title="" class="govuk-link">how to manage cookies</a>.</p>
+            <p>Find out more about <a href="https://ico.org.uk/your-data-matters/online/cookies/">how to manage cookies</a>.</p>
 
             <h2 class="govuk-heading-m govuk-!-margin-top-6">Essential cookies (strictly necessary)</h2>
 

--- a/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/Index.cshtml
@@ -45,7 +45,7 @@ else {
                                 </div>
 
                                 <div class="moj-filter__heading-action">
-                                    <p><button type="submit" class="govuk-link app-button-link govuk-!-font-size-16" name="remove" value="@IFilter.RemoveAll">Clear filters</button></p>
+                                    <p><button type="submit" class="app-button-link govuk-!-font-size-16" name="remove" value="@IFilter.RemoveAll">Clear filters</button></p>
                                 </div>
                             </div>
                     

--- a/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_FilterGroup.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_FilterGroup.cshtml
@@ -47,7 +47,7 @@
                 IFilterOptionalSelect filterOptionalSelect = (IFilterOptionalSelect) Model;
                 <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
                     <div class="govuk-checkboxes__item">
-                        <input class="govuk-checkboxes__input" id="@(filterOptionalSelect.OptionSelectedName)" name="@(filterOptionalSelect.OptionSelectedName)" type="checkbox" value="true" data-aria-controls="@(filterOptionalSelect.Name)-select"
+                        <input class="govuk-checkboxes__input" id="@(filterOptionalSelect.OptionSelectedName)" name="@(filterOptionalSelect.OptionSelectedName)" type="checkbox" value="true" data-aria-controls="@(filterOptionalSelect.Name)-conditional"
                                @if (filterOptionalSelect.IsOptionSelected)
                                {
                                    @:checked
@@ -56,7 +56,7 @@
                             @filterOptionalSelect.OptionDescription
                         </label>
                     </div>
-                        <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="@(filterOptionalSelect.Name)-select">
+                    <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="@(filterOptionalSelect.Name)-conditional">
 
                         <div class="govuk-form-group">
                             <label class="govuk-label" for="@(filterOptionalSelect.Name)-select">

--- a/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_Pagination.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_Pagination.cshtml
@@ -7,7 +7,7 @@
             @if (Model.PreviousPage != null)
             {
                 <div class="govuk-pagination__prev">
-                    <button type="submit" class="govuk-link govuk-pagination__link app-button-link" name="pageNum" value="@Model.PreviousPage">
+                    <button type="submit" class="govuk-pagination__link app-button-link" name="pageNum" value="@Model.PreviousPage">
                         <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
                             <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
                         </svg>
@@ -25,7 +25,7 @@
                     else
                     {
                         <li class="govuk-pagination__item @(item.IsCurrentPage ? "govuk-pagination__item--current" : "")">
-                            <button type="submit" class="govuk-link govuk-pagination__link app-button-link" name="pageNum" value="@item.Page" aria-label="Page @(item.Page)" @(item.IsCurrentPage ? "aria-current=\"page\"" : "")>@item.Page</button>
+                            <button type="submit" class="govuk-pagination__link app-button-link" name="pageNum" value="@item.Page" aria-label="Page @(item.Page)" @(item.IsCurrentPage ? "aria-current=\"page\"" : "")>@item.Page</button>
                         </li>
                     }
                 }
@@ -33,7 +33,7 @@
             @if (Model.NextPage != null)
             {
                 <div class="govuk-pagination__next">
-                    <button type="submit" class="govuk-link govuk-pagination__link app-button-link" name="pageNum" value="@Model.NextPage">
+                    <button type="submit" class="govuk-pagination__link app-button-link" name="pageNum" value="@Model.NextPage">
                         <span class="govuk-pagination__link-title">Next</span>
                         <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
                             <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>

--- a/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_SummaryListLink.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Web/Pages/ServiceFilter/_SummaryListLink.cshtml
@@ -5,21 +5,15 @@
         @Model.Key
     </dt>
     <dd class="govuk-summary-list__value">
-        @if (Model.Value != null)
+        @if (!string.IsNullOrEmpty(Model.Value))
         {
             @switch (Model.LinkType)
             {
                 case LinkType.WebPage:
-                    @if (!string.IsNullOrEmpty(Model.Value))
-                    {
-                        <a href="@(Model.Value)">@(string.IsNullOrEmpty(Model.Description) ? Model.Value : Model.Description)</a>
-                    }
+                    <a href="@(Model.Value)">@(string.IsNullOrEmpty(Model.Description) ? Model.Value : Model.Description)</a>
                     break;
                 case LinkType.WebPageInNewTab:
-                    @if (!string.IsNullOrEmpty(Model.Value))
-                    {
-                        <a href="@(Model.Value)" rel="noreferrer noopener" target="_blank">@(string.IsNullOrEmpty(Model.Description) ? Model.Value : Model.Description) (opens in new tab)</a>
-                    }
+                    <a href="@(Model.Value)" rel="noreferrer noopener" target="_blank">@(string.IsNullOrEmpty(Model.Description) ? Model.Value : Model.Description) (opens in new tab)</a>
                     break;
                 case LinkType.Email:
                     <a href="mailto:@(Model.Value)">@Model.Value</a>

--- a/src/FamilyHubs.ServiceDirectory.Web/Pages/Shared/_CookieBanner.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Web/Pages/Shared/_CookieBanner.cshtml
@@ -18,7 +18,7 @@
             <button value="reject" type="button" name="cookies" class="govuk-button js-cookie-banner-reject" data-module="govuk-button">
                 Reject analytics cookies
             </button>
-            <a class="govuk-link" asp-page="/Cookies/Index">View cookies</a>
+            <a asp-page="/Cookies/Index">View cookies</a>
         </div>
     </div>
 
@@ -26,7 +26,7 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <div class="govuk-cookie-banner__content">
-                    <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" asp-page="/Cookies/Index">change your cookie settings</a> at any time.</p>
+                    <p class="govuk-body">You’ve accepted analytics cookies. You can <a asp-page="/Cookies/Index">change your cookie settings</a> at any time.</p>
                 </div>
             </div>
         </div>
@@ -41,7 +41,7 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <div class="govuk-cookie-banner__content">
-                    <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" asp-page="/Cookies/Index">change your cookie settings</a> at any time.</p>
+                    <p class="govuk-body">You’ve rejected analytics cookies. You can <a asp-page="/Cookies/Index">change your cookie settings</a> at any time.</p>
                 </div>
             </div>
         </div>

--- a/src/FamilyHubs.ServiceDirectory.Web/Pages/Shared/_Layout.cshtml
+++ b/src/FamilyHubs.ServiceDirectory.Web/Pages/Shared/_Layout.cshtml
@@ -68,12 +68,11 @@
 
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/js/govuk-frontend-4.4.0.min.js"></script>
-    <script src="~/js/moj-8.1.0.js"></script>
+@*    <script src="~/js/moj-8.1.0.js"></script>*@
 <script>
         //todo: initialize just the components we use
         window.GOVUKFrontend.initAll();
-        //todo: initialize just the components we use https://design-patterns.service.justice.gov.uk/get-started/setting-up-javascript/
-        window.MOJFrontend.initAll();
+        //window.MOJFrontend.initAll();
     </script>
     
     <script src="~/js/app.js" type="module" asp-append-version="true"></script>

--- a/tests/FamilyHubs.ServiceDirectory.UnitTests/Web/Filtering/PostFilterOptionalSelectTest.cs
+++ b/tests/FamilyHubs.ServiceDirectory.UnitTests/Web/Filtering/PostFilterOptionalSelectTest.cs
@@ -1,0 +1,254 @@
+﻿using FamilyHubs.ServiceDirectory.Web.Filtering;
+using FamilyHubs.ServiceDirectory.Web.Filtering.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace FamilyHubs.ServiceDirectory.UnitTests.Web.Filtering;
+
+// xunit test for PostFilterOptionalSelect in the style of lazcool
+// 
+public class PostFilterOptionalSelectTest
+{
+    public Mock<IFilterOptionalSelect> FilterOptionalSelect { get; set; }
+    public Mock<IFormCollection> Form { get; set; }
+    public string? Remove { get; set; }
+
+    public PostFilterOptionalSelectTest()
+    {
+        FilterOptionalSelect = new Mock<IFilterOptionalSelect>();
+        FilterOptionalSelect.SetupGet(x => x.Name).Returns("TestFilter");
+        Form = new Mock<IFormCollection>();
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor
+    [Fact]
+    public void PostFilterOptionalSelectConstructorTest()
+    {
+        // arrange
+        var remove = "remove";
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(FilterOptionalSelect.Object, Form.Object, remove);
+
+        // assert
+        Assert.Equal(FilterOptionalSelect.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(FilterOptionalSelect.Object.Description, postFilterOptionalSelect.Description);
+        Assert.Equal(FilterOptionalSelect.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(FilterOptionalSelect.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor with null remove
+    // 
+    [Fact]
+    public void PostFilterOptionalSelectConstructorWithNullRemoveTest()
+    {
+        // arrange
+        var filter = new Mock<IFilterOptionalSelect>();
+        var form = new Mock<IFormCollection>();
+        string? remove = null;
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
+
+        // assert
+        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
+        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor with empty remove
+    // 
+    [Fact]
+    public void PostFilterOptionalSelectConstructorWithEmptyRemoveTest()
+    {
+        // arrange
+        var filter = new Mock<IFilterOptionalSelect>();
+        var form = new Mock<IFormCollection>();
+        var remove = string.Empty;
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
+
+        // assert
+        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
+        // continue here
+        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor with remove that starts with filter name
+    [Fact]
+    public void PostFilterOptionalSelectConstructorWithRemoveThatStartsWithFilterNameTest()
+    {
+        // arrange
+        var filter = new Mock<IFilterOptionalSelect>();
+        var form = new Mock<IFormCollection>();
+        var remove = $"{filter.Object.Name}remove";
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
+
+        // assert
+        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
+        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor with remove that does not start with filter name
+    [Fact]
+    public void PostFilterOptionalSelectConstructorWithRemoveThatDoesNotStartWithFilterNameTest()
+    {
+        // arrange
+        var filter = new Mock<IFilterOptionalSelect>();
+        var form = new Mock<IFormCollection>();
+        var remove = $"remove{filter.Object.Name}";
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
+
+        // assert
+        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
+        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name
+    [Fact]
+    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameTest()
+    {
+        // arrange
+        var filter = new Mock<IFilterOptionalSelect>();
+        var form = new Mock<IFormCollection>();
+        var remove = filter.Object.Name;
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
+
+        // assert
+        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
+        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name with spaces
+    [Fact]
+    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameWithSpacesTest()
+    {
+        // arrange
+        var filter = new Mock<IFilterOptionalSelect>();
+        var form = new Mock<IFormCollection>();
+        var remove = $" {filter.Object.Name} ";
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
+
+        // assert
+        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
+        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name with spaces and other characters
+    [Fact]
+    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameWithSpacesAndOtherCharactersTest()
+    {
+        // arrange
+        var filter = new Mock<IFilterOptionalSelect>();
+        var form = new Mock<IFormCollection>();
+        var remove = $" {filter.Object.Name}!@#$%^&*()_+ ";
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
+
+        // assert
+        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
+        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name with spaces and other characters and is not equal to filter name
+    [Fact]
+    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameWithSpacesAndOtherCharactersAndIsNotEqualToFilterNameTest()
+    {
+        // arrange
+        var filter = new Mock<IFilterOptionalSelect>();
+        var form = new Mock<IFormCollection>();
+        var remove = $" {filter.Object.Name}!@#$%^&*()_+remove ";
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
+
+        // assert
+        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
+        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name with spaces and other characters and is equal to filter name
+    [Fact]
+    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameWithSpacesAndOtherCharactersAndIsEqualToFilterNameTest()
+    {
+        // arrange
+        var filter = new Mock<IFilterOptionalSelect>();
+        var form = new Mock<IFormCollection>();
+        var remove = $" {filter.Object.Name}!@#$%^&*()_+{filter.Object.Name} ";
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
+
+        // assert
+        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
+        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+
+    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name with spaces and other characters and is equal to filter name and is not equal to filter name
+    [Fact]
+    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameWithSpacesAndOtherCharactersAndIsEqualToFilterNameAndIsNotEqualToFilterNameTest()
+    {
+        // arrange
+        var filter = new Mock<IFilterOptionalSelect>();
+        var form = new Mock<IFormCollection>();
+        var remove = $" {filter.Object.Name}!@#$%^&*()_+{filter.Object.Name}remove ";
+
+        // act
+        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
+
+        // assert
+        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
+        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
+        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
+        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
+        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
+        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
+    }
+}

--- a/tests/FamilyHubs.ServiceDirectory.UnitTests/Web/Filtering/PostFilterOptionalSelectTest.cs
+++ b/tests/FamilyHubs.ServiceDirectory.UnitTests/Web/Filtering/PostFilterOptionalSelectTest.cs
@@ -5,8 +5,6 @@ using Moq;
 
 namespace FamilyHubs.ServiceDirectory.UnitTests.Web.Filtering;
 
-// xunit test for PostFilterOptionalSelect in the style of lazcool
-// 
 public class PostFilterOptionalSelectTest
 {
     public Mock<IFilterOptionalSelect> FilterOptionalSelect { get; set; }
@@ -20,13 +18,13 @@ public class PostFilterOptionalSelectTest
         Form = new Mock<IFormCollection>();
     }
 
-    // xunit test for PostFilterOptionalSelect constructor
-    [Fact]
-    public void PostFilterOptionalSelectConstructorTest()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("remove")]
+    [InlineData(" remove!@#$%^&*()_+")]
+    public void PostFilterOptionalSelectConstructor(string? remove)
     {
-        // arrange
-        var remove = "remove";
-
         // act
         var postFilterOptionalSelect = new PostFilterOptionalSelect(FilterOptionalSelect.Object, Form.Object, remove);
 
@@ -35,219 +33,6 @@ public class PostFilterOptionalSelectTest
         Assert.Equal(FilterOptionalSelect.Object.Description, postFilterOptionalSelect.Description);
         Assert.Equal(FilterOptionalSelect.Object.FilterType, postFilterOptionalSelect.FilterType);
         Assert.Equal(FilterOptionalSelect.Object.Aspects, postFilterOptionalSelect.Aspects);
-        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
-        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
-    }
-
-    // xunit test for PostFilterOptionalSelect constructor with null remove
-    // 
-    [Fact]
-    public void PostFilterOptionalSelectConstructorWithNullRemoveTest()
-    {
-        // arrange
-        var filter = new Mock<IFilterOptionalSelect>();
-        var form = new Mock<IFormCollection>();
-        string? remove = null;
-
-        // act
-        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
-
-        // assert
-        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
-        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
-        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
-        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
-        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
-        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
-    }
-
-    // xunit test for PostFilterOptionalSelect constructor with empty remove
-    // 
-    [Fact]
-    public void PostFilterOptionalSelectConstructorWithEmptyRemoveTest()
-    {
-        // arrange
-        var filter = new Mock<IFilterOptionalSelect>();
-        var form = new Mock<IFormCollection>();
-        var remove = string.Empty;
-
-        // act
-        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
-
-        // assert
-        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
-        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
-        // continue here
-        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
-        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
-        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
-        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
-    }
-
-    // xunit test for PostFilterOptionalSelect constructor with remove that starts with filter name
-    [Fact]
-    public void PostFilterOptionalSelectConstructorWithRemoveThatStartsWithFilterNameTest()
-    {
-        // arrange
-        var filter = new Mock<IFilterOptionalSelect>();
-        var form = new Mock<IFormCollection>();
-        var remove = $"{filter.Object.Name}remove";
-
-        // act
-        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
-
-        // assert
-        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
-        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
-        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
-        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
-        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
-        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
-    }
-
-    // xunit test for PostFilterOptionalSelect constructor with remove that does not start with filter name
-    [Fact]
-    public void PostFilterOptionalSelectConstructorWithRemoveThatDoesNotStartWithFilterNameTest()
-    {
-        // arrange
-        var filter = new Mock<IFilterOptionalSelect>();
-        var form = new Mock<IFormCollection>();
-        var remove = $"remove{filter.Object.Name}";
-
-        // act
-        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
-
-        // assert
-        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
-        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
-        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
-        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
-        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
-        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
-    }
-
-    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name
-    [Fact]
-    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameTest()
-    {
-        // arrange
-        var filter = new Mock<IFilterOptionalSelect>();
-        var form = new Mock<IFormCollection>();
-        var remove = filter.Object.Name;
-
-        // act
-        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
-
-        // assert
-        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
-        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
-        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
-        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
-        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
-        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
-    }
-
-    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name with spaces
-    [Fact]
-    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameWithSpacesTest()
-    {
-        // arrange
-        var filter = new Mock<IFilterOptionalSelect>();
-        var form = new Mock<IFormCollection>();
-        var remove = $" {filter.Object.Name} ";
-
-        // act
-        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
-
-        // assert
-        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
-        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
-        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
-        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
-        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
-        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
-    }
-
-    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name with spaces and other characters
-    [Fact]
-    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameWithSpacesAndOtherCharactersTest()
-    {
-        // arrange
-        var filter = new Mock<IFilterOptionalSelect>();
-        var form = new Mock<IFormCollection>();
-        var remove = $" {filter.Object.Name}!@#$%^&*()_+ ";
-
-        // act
-        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
-
-        // assert
-        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
-        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
-        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
-        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
-        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
-        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
-    }
-
-    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name with spaces and other characters and is not equal to filter name
-    [Fact]
-    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameWithSpacesAndOtherCharactersAndIsNotEqualToFilterNameTest()
-    {
-        // arrange
-        var filter = new Mock<IFilterOptionalSelect>();
-        var form = new Mock<IFormCollection>();
-        var remove = $" {filter.Object.Name}!@#$%^&*()_+remove ";
-
-        // act
-        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
-
-        // assert
-        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
-        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
-        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
-        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
-        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
-        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
-    }
-
-    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name with spaces and other characters and is equal to filter name
-    [Fact]
-    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameWithSpacesAndOtherCharactersAndIsEqualToFilterNameTest()
-    {
-        // arrange
-        var filter = new Mock<IFilterOptionalSelect>();
-        var form = new Mock<IFormCollection>();
-        var remove = $" {filter.Object.Name}!@#$%^&*()_+{filter.Object.Name} ";
-
-        // act
-        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
-
-        // assert
-        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
-        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
-        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
-        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
-        Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
-        Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
-    }
-
-    // xunit test for PostFilterOptionalSelect constructor with remove that is filter name with spaces and other characters and is equal to filter name and is not equal to filter name
-    [Fact]
-    public void PostFilterOptionalSelectConstructorWithRemoveThatIsFilterNameWithSpacesAndOtherCharactersAndIsEqualToFilterNameAndIsNotEqualToFilterNameTest()
-    {
-        // arrange
-        var filter = new Mock<IFilterOptionalSelect>();
-        var form = new Mock<IFormCollection>();
-        var remove = $" {filter.Object.Name}!@#$%^&*()_+{filter.Object.Name}remove ";
-
-        // act
-        var postFilterOptionalSelect = new PostFilterOptionalSelect(filter.Object, form.Object, remove);
-
-        // assert
-        Assert.Equal(filter.Object.Name, postFilterOptionalSelect.Name);
-        Assert.Equal(filter.Object.Description, postFilterOptionalSelect.Description);
-        Assert.Equal(filter.Object.FilterType, postFilterOptionalSelect.FilterType);
-        Assert.Equal(filter.Object.Aspects, postFilterOptionalSelect.Aspects);
         Assert.Equal(Array.Empty<IFilterAspect>(), postFilterOptionalSelect.SelectedAspects);
         Assert.Equal(Enumerable.Empty<string>(), postFilterOptionalSelect.Values);
     }


### PR DESCRIPTION
Includes:
* fix 2 elements with the same id on filter page (reported by axe as: IDs used in ARIA and labels must be unique)
* don't create a link for an empty email or phone (reported by axe as: Links must have discernible text)
* don't include MOJ's JS file (it's not needed)
* more unit tests & tidy ups